### PR TITLE
Migrate extension to Manifest V3

### DIFF
--- a/background.js
+++ b/background.js
@@ -28,9 +28,11 @@ function tabs() {
   chrome.tabs.query({windowId: chrome.windows.WINDOW_ID_CURRENT}, function(tabList) {
     total = tabList.length
     for (var i = 0; i < tabList.length; i++) {
-      const newTitle = indexTitle(tabList[i].index, tabList[i].title, total)
+      const tab = tabList[i]
+      if (!tab.url || tab.url.startsWith("chrome://") || tab.url.startsWith("chrome-extension://") || tab.url.startsWith("about:")) continue
+      const newTitle = indexTitle(tab.index, tab.title, total)
       chrome.scripting.executeScript({
-        target: { tabId: tabList[i].id },
+        target: { tabId: tab.id },
         func: (title) => { document.title = title },
         args: [newTitle]
       })

--- a/background.js
+++ b/background.js
@@ -9,10 +9,10 @@ function indexTitle(index, title, max) {
 
   if (enabled == false) { return originalTitle }
 
-    if (index > 7 && index == max-1) { 
+    if (index > 7 && index == max-1) {
         return "".concat("9".toString(), separator, originalTitle)
     }
-    else if (index > 7) { 
+    else if (index > 7) {
         if(title[0] === "9" && title[1] === "]"){
             return title.substring(2);
         } else{
@@ -25,28 +25,26 @@ function indexTitle(index, title, max) {
 }
 
 function tabs() {
-  chrome.tabs.query({windowId: chrome.windows.WINDOW_ID_CURRENT}, function(tabs) {
-    total = tabs.length
-    for (var i = 0; i < tabs.length; i++) {
-     chrome.tabs.executeScript(tabs[i].id, 
-         { code: "chrome.runtime.sendMessage({'index': ".concat(tabs[i].index, 
-             ", 'id': ", 
-             tabs[i].id, 
-             ", 'title': '", 
-             tabs[i].title, 
-             "' })") })
+  chrome.tabs.query({windowId: chrome.windows.WINDOW_ID_CURRENT}, function(tabList) {
+    total = tabList.length
+    for (var i = 0; i < tabList.length; i++) {
+      const newTitle = indexTitle(tabList[i].index, tabList[i].title, total)
+      chrome.scripting.executeScript({
+        target: { tabId: tabList[i].id },
+        func: (title) => { document.title = title },
+        args: [newTitle]
+      })
     }
-  }
-)}
+  })
+}
 
 function callbackTab(tab){
     if(enabled){
-        enabled = true;
         tabs()
     }
 }
 
-chrome.commands.onCommand.addListener(function(command) { 
+chrome.commands.onCommand.addListener(function(command) {
   enabled = enabled ? false : true;
   tabs()
 })
@@ -58,9 +56,3 @@ chrome.tabs.onActivated.addListener((tab) => callbackTab(tab));
 chrome.tabs.onRemoved.addListener((tab) => callbackTab(tab));
 
 chrome.tabs.onMoved.addListener((tab) => callbackTab(tab));
-
-
-
-chrome.runtime.onMessage.addListener(function(message, sender) {
-  chrome.tabs.executeScript(message.id, { code: "document.title=".concat('"', indexTitle(message.index, message.title, total), '"') } )
-})

--- a/manifest.json
+++ b/manifest.json
@@ -1,19 +1,21 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
 
   "name": "Numbered Tabs",
   "description": "See order of your open tabs to navigate easily",
   "version": "0.1",
 
   "permissions": [
+    "tabs",
+    "scripting"
+  ],
+  "host_permissions": [
     "file://*/*",
     "http://*/*",
-    "https://*/*",
-    "tabs"
+    "https://*/*"
   ],
   "background": {
-    "persistent": false,
-    "scripts": ["background.js"]
+    "service_worker": "background.js"
   },
   "commands" : {
     "toggle_title" : {


### PR DESCRIPTION
## Summary

- Bump `manifest_version` from 2 to 3 (Chrome no longer supports MV2)
- Replace `background.scripts` with `service_worker`
- Move URL patterns (`http://*/*`, `https://*/*`, `file://*/*`) to `host_permissions`
- Add `scripting` permission required by MV3
- Replace deprecated `chrome.tabs.executeScript` with `chrome.scripting.executeScript`
- Simplify tab update logic: compute new title in background and inject directly, removing unnecessary message-passing round-trip

## Test plan

- [x] Load unpacked extension in `chrome://extensions` — should load without errors
- [x] Open multiple tabs and verify they get numbered prefixes (e.g. `1] Title`, `2] Title`)
- [x] Press `Alt+T` to toggle numbering on/off
- [x] Open/close/move tabs and verify numbers update correctly